### PR TITLE
Replace mmap-go dependency with a fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,3 +87,6 @@ require (
 	k8s.io/client-go v0.31.1 // indirect
 	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 // indirect
 )
+
+// Replace edsrzf/mmap-go with a fork that supports compile for WASM.
+replace github.com/edsrzf/mmap-go v1.1.0 => github.com/ajalab/mmap-go v0.0.0-20241008023454-ed77fde4691b

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mx
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/ajalab/mmap-go v0.0.0-20241008023454-ed77fde4691b h1:PrucTNJVPoBB5cp8kOzGwhWq+vOuiQr8Wwr/jR5p4M4=
+github.com/ajalab/mmap-go v0.0.0-20241008023454-ed77fde4691b/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
@@ -50,8 +52,6 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
-github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb h1:IT4JYU7k4ikYg1SCxNI1/Tieq/NFvh6dzLdgi7eu0tM=
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=


### PR DESCRIPTION
```sh
$ GOOS=js GOARCH=wasm go build -o slom-wasm
# github.com/edsrzf/mmap-go
../../go/pkg/mod/github.com/edsrzf/mmap-go@v1.1.0/mmap.go:77:9: undefined: mmap
../../go/pkg/mod/github.com/edsrzf/mmap-go@v1.1.0/mmap.go:92:11: m.lock undefined (type MMap has no field or method lock, but does have method Lock)
../../go/pkg/mod/github.com/edsrzf/mmap-go@v1.1.0/mmap.go:99:11: m.unlock undefined (type MMap has no field or method unlock, but does have method Unlock)
../../go/pkg/mod/github.com/edsrzf/mmap-go@v1.1.0/mmap.go:104:11: m.flush undefined (type MMap has no field or method flush, but does have method Flush)
../../go/pkg/mod/github.com/edsrzf/mmap-go@v1.1.0/mmap.go:114:11: m.unmap undefined (type *MMap has no field or method unmap, but does have method Unmap)
```

Currently, this project can't build for `wasm` architecture due to the lack of its support in [mmap-go](https://github.com/edsrzf/mmap-go). It depends on this module through `github.com/prometheus/prometheus/promql` package.

```sh
$ go mod why -m github.com/edsrzf/mmap-go
# github.com/edsrzf/mmap-go
github.com/ajalab/slom/internal/prometheus/rule
github.com/prometheus/prometheus/model/rulefmt
github.com/prometheus/prometheus/promql
github.com/edsrzf/mmap-go
```

Until https://github.com/edsrzf/mmap-go/pull/35 is merged, let's replace this dependency with a fork that adds the WASM compile support.