### PR TITLE
Rename v1alpha package to v1alpha1

### DIFF
--- a/cmd/generate/document/document.go
+++ b/cmd/generate/document/document.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/ajalab/slom/cmd/common"
-	configspec "github.com/ajalab/slom/internal/config/spec/native/v1alpha"
+	configspec "github.com/ajalab/slom/internal/config/spec/native/v1alpha1"
 	"github.com/ajalab/slom/internal/document"
 	"github.com/ajalab/slom/internal/print"
 	"github.com/ajalab/slom/internal/spec"

--- a/cmd/generate/prometheus/rule/rule.go
+++ b/cmd/generate/prometheus/rule/rule.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/ajalab/slom/cmd/common"
-	configspec "github.com/ajalab/slom/internal/config/spec/native/v1alpha"
+	configspec "github.com/ajalab/slom/internal/config/spec/native/v1alpha1"
 	"github.com/ajalab/slom/internal/print"
 	"github.com/ajalab/slom/internal/prometheus/rule"
 	"github.com/ajalab/slom/internal/spec"

--- a/cmd/generate/prometheus/tsdb/tsdb.go
+++ b/cmd/generate/prometheus/tsdb/tsdb.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ajalab/slom/cmd/common"
 	configseries "github.com/ajalab/slom/internal/config/series"
-	configspec "github.com/ajalab/slom/internal/config/spec/native/v1alpha"
+	configspec "github.com/ajalab/slom/internal/config/spec/native/v1alpha1"
 	"github.com/ajalab/slom/internal/prometheus/rule"
 	"github.com/ajalab/slom/internal/prometheus/series"
 	"github.com/ajalab/slom/internal/prometheus/tsdb"

--- a/internal/config/spec/core/v1alpha1/config.go
+++ b/internal/config/spec/core/v1alpha1/config.go
@@ -1,4 +1,4 @@
-package v1alpha
+package v1alpha1
 
 // SpecConfig is a configuration for an SLO specification.
 // An SLO specification typically corresponds to a specific service or user journey and may include multiple SLO entries.

--- a/internal/config/spec/native/v1alpha1/config.go
+++ b/internal/config/spec/native/v1alpha1/config.go
@@ -1,7 +1,7 @@
-package v1alpha
+package v1alpha1
 
 import (
-	core "github.com/ajalab/slom/internal/config/spec/core/v1alpha"
+	core "github.com/ajalab/slom/internal/config/spec/core/v1alpha1"
 )
 
 // SpecConfig is a configuration for an SLO specification.

--- a/internal/config/spec/native/v1alpha1/parse.go
+++ b/internal/config/spec/native/v1alpha1/parse.go
@@ -1,4 +1,4 @@
-package v1alpha
+package v1alpha1
 
 import (
 	"io"

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	core "github.com/ajalab/slom/internal/config/spec/core/v1alpha"
-	native "github.com/ajalab/slom/internal/config/spec/native/v1alpha"
+	core "github.com/ajalab/slom/internal/config/spec/core/v1alpha1"
+	native "github.com/ajalab/slom/internal/config/spec/native/v1alpha1"
 	"github.com/prometheus/common/model"
 )
 


### PR DESCRIPTION
Related: #3 

To follow the same version name convention as Kubernetes.