### PR TITLE
Remove .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-**/*_test.go
-examples
-testdata


### PR DESCRIPTION
To remove `+dirty` and make the build consistent with `go install`.

```
$ docker run ghcr.io/ajalab/slom:v0.3.0-alpha1 version
slom version v0.3.0-alpha1+dirty
  go version: go1.24.11
  platform: linux/amd64
```